### PR TITLE
Bump cryptography from 3.3.2 to 39.0.1 in /Requirements

### DIFF
--- a/Requirements/GassistPi-pip-requirements.txt
+++ b/Requirements/GassistPi-pip-requirements.txt
@@ -24,7 +24,7 @@ google-cloud-texttospeech==0.3.0
 google-cloud-speech==0.36.0
 adafruit-io==2.1
 pywemo==0.4.39
-cryptography==3.3.2
+cryptography==39.0.1
 mock==3.0.5
 oauth2client
 pvporcupine==1.9.5


### PR DESCRIPTION
### Description

The dependency version for `cryptography` in the `Requirements/GassistPi-pip-requirements.txt` file has been updated from `3.3.2` to `39.0.1`.

Changes:
- Updated the `cryptography` version in the requirements file from `3.3.2` to `39.0.1`.